### PR TITLE
Fix missing field for robots tag

### DIFF
--- a/src/Resources/contao/dca/tl_portfolio.php
+++ b/src/Resources/contao/dca/tl_portfolio.php
@@ -179,7 +179,7 @@ $GLOBALS['TL_DCA']['tl_portfolio'] = [
             'sql'       => "varchar(255) NOT NULL default ''",
         ],
         'pageTitle' => [
-
+        
             'exclude'                 => true,
             'search'                  => true,
             'inputType'               => 'text',

--- a/src/Resources/contao/dca/tl_portfolio.php
+++ b/src/Resources/contao/dca/tl_portfolio.php
@@ -111,7 +111,7 @@ $GLOBALS['TL_DCA']['tl_portfolio'] = [
     // Palettes
     'palettes'    => [
         '__selector__' => ['addImage', 'source', 'overwriteMeta'],
-        'default'      => '{title_legend},headline,alias,categories,client;{meta_legend},pageTitle,description,serpPreview;{teaser_legend},teaser;{date_legend},date;{image_legend},addImage;{source_legend:hide},source;{expert_legend:hide},cssClass,noComments,featured;{publish_legend},published,start,stop',
+        'default'      => '{title_legend},headline,alias,categories,client;{meta_legend},pageTitle,robots,description,serpPreview;{teaser_legend},teaser;{date_legend},date;{image_legend},addImage;{source_legend:hide},source;{expert_legend:hide},cssClass,noComments,featured;{publish_legend},published,start,stop',
     ],
 
     // Subpalettes
@@ -179,12 +179,20 @@ $GLOBALS['TL_DCA']['tl_portfolio'] = [
             'sql'       => "varchar(255) NOT NULL default ''",
         ],
         'pageTitle' => [
-        
+
             'exclude'                 => true,
             'search'                  => true,
             'inputType'               => 'text',
             'eval'                    => array('maxlength'=>255, 'decodeEntities'=>true, 'tl_class'=>'w50'),
             'sql'                     => "varchar(255) NOT NULL default ''"
+        ],
+        'robots' => [
+            'exclude'                 => true,
+            'search'                  => true,
+            'inputType'               => 'select',
+            'options'                 => ['index,follow', 'index,nofollow', 'noindex,follow', 'noindex,nofollow'],
+            'eval'                    => ['tl_class' =>'w50', 'includeBlankOption' => true],
+            'sql'                     => "varchar(32) NOT NULL default ''"
         ],
         'description' => [
             'exclude'                 => true,

--- a/src/Resources/contao/languages/de/tl_portfolio.xlf
+++ b/src/Resources/contao/languages/de/tl_portfolio.xlf
@@ -61,6 +61,14 @@
         <source>Here you can add a custom meta title to overwrite the default page title.</source>
         <target>Hier können Sie einen individuellen Meta-Titel eingeben, um den Standard-Seitentitel zu überschreiben.</target>
       </trans-unit>
+      <trans-unit id="tl_portfolio.robots.0">
+        <source>Robots tag</source>
+        <target>Robots-Tag</target>
+      </trans-unit>
+      <trans-unit id="tl_portfolio.robots.1">
+        <source>Here you can define a custom robots tag to overwrite the default page settings.</source>
+        <target>Hier können Sie individuelle Robots-Tag auswählen, um die Standard-Seiteneinstellungen zu überschreiben.</target>
+      </trans-unit>
       <trans-unit id="tl_portfolio.description.0">
         <source>Meta description</source>
         <target>Meta-Beschreibung</target>


### PR DESCRIPTION
The `robots` field is already taken into account while generating the sitemap and the reader page.
But you cannot select it in the portfolio 😞 

Maybe the CS fixer should be run again!