### PR TITLE
Fix undefined variable in ModulePortfolioList

### DIFF
--- a/src/Modules/ModulePortfolioList.php
+++ b/src/Modules/ModulePortfolioList.php
@@ -17,6 +17,7 @@ use Contao\Config;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\Environment;
 use Contao\Input;
+use Contao\Model\Collection;
 use Contao\Pagination;
 use Contao\StringUtil;
 use EuF\PortfolioBundle\Models\PortfolioCategoryModel;
@@ -190,7 +191,7 @@ class ModulePortfolioList extends ModulePortfolio
      * @param int   $limit
      * @param int   $offset
      *
-     * @return Collection|NewsModel|null
+     * @return Collection|PortfolioModel[]|PortfolioModel|null
      */
     protected function fetchItems($portfolioArchives, $blnFeatured, $limit, $offset, $arrCategories)
     {

--- a/src/Modules/ModulePortfolioList.php
+++ b/src/Modules/ModulePortfolioList.php
@@ -194,7 +194,7 @@ class ModulePortfolioList extends ModulePortfolio
      */
     protected function fetchItems($portfolioArchives, $blnFeatured, $limit, $offset, $arrCategories)
     {
-        $order .= 'tl_portfolio.sorting ASC';
+        $order = 'tl_portfolio.sorting ASC';
 
         return PortfolioModel::findPublishedByPids($portfolioArchives, $blnFeatured, $limit, $offset, ['order' => $order], $arrCategories);
     }


### PR DESCRIPTION
While activating the debug mode you will see the error `Warning: Undefined variable $order`.
This PR will fix this problem and adds the correct return types to the `fetchItems`